### PR TITLE
add target for easy update of cobol-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,7 @@ autotest:	build
 init-submodules:
 	git submodule init
 	git submodule update
+
+update-cobol-build:
+	cd $(BUILDROOT) && git pull origin master
+	git commit $(BUILDROOT) -e -m 'update cobol-build'


### PR DESCRIPTION
just run `make update-cobol-build` to upgrade to the latest and greatest version of `cobol-build`